### PR TITLE
Updated app.json for heroku 20 stack

### DIFF
--- a/app.json
+++ b/app.json
@@ -104,6 +104,7 @@
           "required": false  
         }
     },
+  "stack": "heroku-20",
   "addons": [
     {
       "plan": "heroku-postgresql",


### PR DESCRIPTION
As the default stack for heroku is 22, but deadly spam bot do not support heroku 22 stack. So update this 👀